### PR TITLE
feature: bitmex eth perpetual contract support

### DIFF
--- a/server/src/exchanges/bitmex.js
+++ b/server/src/exchanges/bitmex.js
@@ -9,6 +9,7 @@ class Bitmex extends Exchange {
 		this.id = 'bitmex';
 
 		this.mapping = {
+			ETHUSD: 'ETHUSD',
 			BTCUSD: 'XBTUSD',
 			ADABTC: 'ADAM18',
 			BCHBTC: 'BCHM18',


### PR DESCRIPTION
BITMEX opened ETH contracts since 02 aug
https://www.bitmex.com/app/contract/ETHUSD
So, why not?