### PR TITLE
Update and fix Bitmex symbols

### DIFF
--- a/server/src/exchanges/bitmex.js
+++ b/server/src/exchanges/bitmex.js
@@ -11,11 +11,12 @@ class Bitmex extends Exchange {
 		this.mapping = {
 			ETHUSD: 'ETHUSD',
 			BTCUSD: 'XBTUSD',
-			ADABTC: 'ADAM18',
-			BCHBTC: 'BCHM18',
-			ETHBTC: 'ETHM18',
-			LTCBTC: 'LTCM18',
-			XRPBTC: 'XRPM18',
+			EOSBTC: 'EOSU18',
+			ADABTC: 'ADAU18',
+			BCHBTC: 'BCHU18',
+			ETHBTC: 'ETHU18',
+			LTCBTC: 'LTCU18',
+			XRPBTC: 'XRPU18',
 		}
 
 		this.options = Object.assign({


### PR DESCRIPTION
Bitmex: add symbol EOSU18(BTC) and set other BTC pair's counter value to U18