### PR TITLE
Respect custom BitMEX Btc pair names

### DIFF
--- a/src/exchanges/bitmex.js
+++ b/src/exchanges/bitmex.js
@@ -90,7 +90,7 @@ class Bitmex extends Exchange {
 	}
 
 	matchPairName(name) {
-		return name.replace('/[A-Z]18/gi', 'BTC');	
+		return name.replace('/[A-Z][0-9]{2}/gi', 'BTC');	
 	}
 
 }

--- a/src/exchanges/bitmex.js
+++ b/src/exchanges/bitmex.js
@@ -89,6 +89,10 @@ class Bitmex extends Exchange {
 		return output;
 	}
 
+	matchPairName(name) {
+		return name.replace('/[A-Z]18/gi', 'BTC');	
+	}
+
 }
 
 export default Bitmex;


### PR DESCRIPTION
This maps the custom BitMEX Btc pair names to normal Btc names. 