### PR TITLE
Update Okex to compensate for lag in trades received

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -684,8 +684,8 @@
               <input
                 type="checkbox"
                 class="form-control"
-                :checked="showSpray"
-                @change="$store.commit('showSpray', $event.target.checked)"
+                :checked="tradeSpray"
+                @change="$store.commit('toggleTradeSpray', $event.target.checked)"
               />
               <div></div>
               <span>Show spray in basis points</span>
@@ -759,6 +759,7 @@ export default {
       'showLogos',
       'liquidationsOnlyList',
       'aggregationLag',
+      'tradeSpray',
       'showCounters',
       'showStats',
       'statsPeriod',

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -677,6 +677,21 @@
             </label>
           </div>
         </div>
+        <div class="form-group mb8">
+            <label
+              class="checkbox-control"
+            >
+              <input
+                type="checkbox"
+                class="form-control"
+                :checked="showSpray"
+                @change="$store.commit('showSpray', $event.target.checked)"
+              />
+              <div></div>
+              <span>Show spray in basis points</span>
+            </label>
+          </div>
+        </div>
         <div class="mt15 settings__footer flex-middle">
           <div class="form-group">
             <div v-if="version.number">

--- a/src/components/TradeList.vue
+++ b/src/components/TradeList.vue
@@ -27,7 +27,7 @@
           <div class="trades__item__price">
             <span class="icon-quote"></span>
             <span v-html="trade.price"></span>
-            <span class="trade__spray" v-html="trade.spray"></span>
+            <span v-if="trade.spray" class="trade__spray">{{ trade.spray }}</span>
           </div>
           <div class="trades__item__amount">
             <span class="trades__item__amount__quote"
@@ -77,6 +77,7 @@ export default {
       'preferQuoteCurrencySize',
       'decimalPrecision',
       'aggregationLag',
+      'tradeSpray',
       'showLogos',
     ]),
   },
@@ -296,6 +297,12 @@ export default {
         image = 'url(' + image + ')'
       }
 
+      let spray
+
+      if (this.tradeSpray && trade[6]) {
+        spray = ' - ' + trade[6] + 'bps'
+      }
+
       this.trades.unshift({
         id: Math.random()
           .toString(36)
@@ -312,7 +319,7 @@ export default {
         date: this.$root.ago(trade[1]),
         timestamp: trade[1],
         image: image,
-        spray:  trade[6] ? ' - ' + trade[6] + 'bps': '',
+        spray: spray,
         message: message,
       })
 
@@ -718,12 +725,6 @@ export default {
   }
 }
 
-.trades__spray  {
-
-    opacity: 0;
-  
-}
-
 #app[data-prefer='base'] .trades__item .trades__item__amount {
   .trades__item__amount__quote {
     transform: translateX(-25%);
@@ -746,12 +747,6 @@ export default {
       opacity: 1;
     }
   }
-}
-
-#app[data-showSpray='showSpray']  .trades__spray  {
-
-    opacity: 0;
-  
 }
 
 </style>

--- a/src/components/TradeList.vue
+++ b/src/components/TradeList.vue
@@ -27,6 +27,7 @@
           <div class="trades__item__price">
             <span class="icon-quote"></span>
             <span v-html="trade.price"></span>
+            <span class="trade__spray" v-html="trade.spray"></span>
           </div>
           <div class="trades__item__amount">
             <span class="trades__item__amount__quote"
@@ -311,6 +312,7 @@ export default {
         date: this.$root.ago(trade[1]),
         timestamp: trade[1],
         image: image,
+        spray:  trade[6] ? ' - ' + trade[6] + 'bps': '',
         message: message,
       })
 
@@ -716,6 +718,12 @@ export default {
   }
 }
 
+.trades__spray  {
+
+    opacity: 0;
+  
+}
+
 #app[data-prefer='base'] .trades__item .trades__item__amount {
   .trades__item__amount__quote {
     transform: translateX(-25%);
@@ -739,4 +747,11 @@ export default {
     }
   }
 }
+
+#app[data-showSpray='showSpray']  .trades__spray  {
+
+    opacity: 0;
+  
+}
+
 </style>

--- a/src/exchanges/okex.js
+++ b/src/exchanges/okex.js
@@ -62,16 +62,10 @@ class Okex extends Exchange {
 
     // if theres trades in the stack, dispatch them to emitter.
     if (this.tradeStack.length > 0) {
-      this.tradeStack[0][6] = Math.round(
-        ((this.tradeStackMax - this.tradeStackMin) / this.tradeStackMin) * 10000
-      )
-
       this.emitTrades(this.tradeStack)
 
       // clear stack
       this.tradeStack.splice(0, this.tradeStack.length)
-      this.tradeStackMin = Infinity
-      this.tradeStackMax = 0
     }
   }
 
@@ -100,9 +94,6 @@ class Okex extends Exchange {
         // dispatch the last stack (expired)
         this.dispatchTrades()
       }
-
-      this.tradeStackMin = Math.min(this.tradeStackMin, trades[0][2])
-      this.tradeStackMax = Math.max(this.tradeStackMax, trades[0][2])
 
         // push the last trade
       this.tradeStack.push(trades[0])

--- a/src/exchanges/okex.js
+++ b/src/exchanges/okex.js
@@ -52,12 +52,7 @@ class Okex extends Exchange {
     )
   }
 
-  dispatchTrades(manual = false) {
-    !manual && console.log('timer fired', this.tradeStack.map(a => {
-      const d = new Date(a[1])
-      return d.toLocaleTimeString() + '.' + d.getMilliseconds()
-    }))
-
+  dispatchTrades() {
     // check if a timeout is in progress
     if (this.dispatchTradesTimeout) {
       clearTimeout(this.dispatchTradesTimeout)
@@ -95,7 +90,7 @@ class Okex extends Exchange {
       } else if (trades.length > 1) {
         // if a group of trades is received (likely in the spot) our job is already done so push them directly.
         // dispatch any old trades
-        this.dispatchTrades(true)
+        this.dispatchTrades()
 
         // immediately dispatch new trades
         this.emitTrades(trades)
@@ -103,7 +98,7 @@ class Okex extends Exchange {
         return
       } else if (this.tradeStack.length && this.tradeStack[0][1] !== trades[0][1]) {
         // dispatch the last stack (expired)
-        this.dispatchTrades(true)
+        this.dispatchTrades()
       }
 
       this.tradeStackMin = Math.min(this.tradeStackMin, trades[0][2])

--- a/src/services/exchange.js
+++ b/src/services/exchange.js
@@ -153,13 +153,15 @@ class Exchange extends EventEmitter {
    * groupTrades makes sure the output is a single $1000000 
    * and not 20 multiple trades which would show as multiple 100k$ in the TradeList
    *
-   * @param {*} trades
+   * @param {*} trades -[0]id -[1]date -[2]price -[3]size -[4]side
    * @returns
-   * @memberof Exchange
+   * @memberof Exchange 
    */
   groupTrades(trades) {
     const group = {}
     const sums = {}
+    const mins = {}
+    const maxs = {}
     const output = []
 
     for (let trade of trades) {
@@ -174,8 +176,19 @@ class Exchange extends EventEmitter {
         group[id][2] += +trade[2]
         group[id][3] += +trade[3]
         sums[id] += trade[2] * trade[3]
+        
+        //Record max and min price of the trade
+        if( trade[2] > maxs[id] ){
+            maxs[id] = trade[2]
+            
+        } else if ( trade[2] < mins[id] ){
+            mins[id] = trade[2]
+        }
+        
       } else {
         group[id] = trade
+        mins[id] = trade[2]
+        maxs[id] = trade[2]
 
         sums[id] = trade[2] * trade[3];
       }
@@ -185,7 +198,8 @@ class Exchange extends EventEmitter {
 
     for (let i = 0; i < ids.length; i++) {
       group[ids[i]][2] = sums[ids[i]] / group[ids[i]][3]
-
+      group[ids[i]][6] = Math.round(((maxs[ids[i]]-mins[ids[i]])/mins[ids[i]])*10000)
+      
       output.push(group[ids[i]]);
     }
 

--- a/src/services/exchange.js
+++ b/src/services/exchange.js
@@ -160,8 +160,6 @@ class Exchange extends EventEmitter {
   groupTrades(trades) {
     const group = {}
     const sums = {}
-    const mins = {}
-    const maxs = {}
     const output = []
 
     for (let trade of trades) {
@@ -176,19 +174,8 @@ class Exchange extends EventEmitter {
         group[id][2] += +trade[2]
         group[id][3] += +trade[3]
         sums[id] += trade[2] * trade[3]
-        
-        //Record max and min price of the trade
-        if( trade[2] > maxs[id] ){
-            maxs[id] = trade[2]
-            
-        } else if ( trade[2] < mins[id] ){
-            mins[id] = trade[2]
-        }
-        
       } else {
         group[id] = trade
-        mins[id] = trade[2]
-        maxs[id] = trade[2]
 
         sums[id] = trade[2] * trade[3];
       }
@@ -198,8 +185,7 @@ class Exchange extends EventEmitter {
 
     for (let i = 0; i < ids.length; i++) {
       group[ids[i]][2] = sums[ids[i]] / group[ids[i]][3]
-      group[ids[i]][6] = Math.round(((maxs[ids[i]]-mins[ids[i]])/mins[ids[i]])*10000)
-      
+
       output.push(group[ids[i]]);
     }
 

--- a/src/services/exchange.js
+++ b/src/services/exchange.js
@@ -1,4 +1,5 @@
 import EventEmitter from 'eventemitter3'
+import store from '../services/store'
 
 class Exchange extends EventEmitter {
   constructor(options) {
@@ -160,6 +161,8 @@ class Exchange extends EventEmitter {
   groupTrades(trades) {
     const group = {}
     const sums = {}
+    const mins = {}
+    const maxs = {}
     const output = []
 
     for (let trade of trades) {
@@ -174,6 +177,11 @@ class Exchange extends EventEmitter {
         group[id][2] += +trade[2]
         group[id][3] += +trade[3]
         sums[id] += trade[2] * trade[3]
+
+        if (store.state.tradeSpray) {
+          mins[id] = Math.min(mins[id] || Infinity, trade[2])
+          maxs[id] = Math.max(mins[id] || 0, trade[2])
+        }
       } else {
         group[id] = trade
 
@@ -185,6 +193,10 @@ class Exchange extends EventEmitter {
 
     for (let i = 0; i < ids.length; i++) {
       group[ids[i]][2] = sums[ids[i]] / group[ids[i]][3]
+
+      if (mins[ids[i]]) {
+        group[ids[i]][6] = Math.round(((maxs[ids[i]]-mins[ids[i]])/mins[ids[i]])*10000)
+      }
 
       output.push(group[ids[i]]);
     }

--- a/src/services/store.js
+++ b/src/services/store.js
@@ -42,6 +42,7 @@ const DEFAULTS = {
   maxRows: 20,
   decimalPrecision: null,
   aggregationLag: null,
+  tradeSpray: false,
   showLogos: false,
   liquidationsOnlyList: false,
   showCounters: false,
@@ -191,6 +192,9 @@ const store = new Vuex.Store({
     },
     setAggregationLag(state, value) {
       state.aggregationLag = value
+    },
+    toggleTradeSpray(state, value) {
+      state.tradeSpray = value ? true : false
     },
     toggleLogos(state, value) {
       state.showLogos = value ? true : false


### PR DESCRIPTION
Added a tradeStack to the OKex class which stores received trades (that have the same timestamp) for 30ms, before emitting.  If a trade is received that contains a different (newer) timestamp, the old stack will be pushed, and the new trade added to the blank stack.

fixes #47 

Not sure how you feel about adding a timeout at the exchange level but maybe this is a solution!