### PR TITLE
Updated the colour of binance futures svg

### DIFF
--- a/static/exchanges/binance_futures.svg
+++ b/static/exchanges/binance_futures.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
 <style type="text/css">
-	.st0{fill:#15151C;}
+	.st0{fill:#f3ba2f;}
 </style>
 <path class="st0" d="M4.9,6.7L8,3.6l3.1,3.1l1.8-1.8L8,0L3.1,4.9L4.9,6.7z M0,8l1.8-1.8L3.6,8L1.8,9.8L0,8z M4.9,9.3L8,12.4l3.1-3.1
 	l1.8,1.8L8,16l-4.9-4.9L4.9,9.3z M12.4,8l1.8-1.8L16,8l-1.8,1.8L12.4,8z M9.8,8L8,6.2L6.2,8L8,9.8L9.8,8z"/>


### PR DESCRIPTION
Unable to see the logo against the black background as the logo is black.

Changed to the same colour as binance, might not be the best solution.