### PR TITLE
fix huobi, fix devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "node-sass": "^4.12.0",
     "sass-loader": "^6.0.6",
     "sass-resources-loader": "^1.3.3",
+    "vue-hot-reload-api": "^2.3.4",
     "vue-loader": "^13.0.5",
+    "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.4.4",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"

--- a/src/exchanges/huobi.js
+++ b/src/exchanges/huobi.js
@@ -78,7 +78,7 @@ class Huobi extends Exchange {
       for (let pair of this.pairs) {
         this.api.send(
           JSON.stringify({
-            sub: 'market.' + pair + '.trade.detail',
+            sub: 'market.' + pair.toLowerCase() + '.trade.detail',
             id: pair,
           })
         )


### PR DESCRIPTION
fixed: Huobi Exchange: Upper cased pair name in detail subscribe string causing "invalid symbol" error.