### PR TITLE
fix bitstamp disconnect method

### DIFF
--- a/src/exchanges/bitstamp.js
+++ b/src/exchanges/bitstamp.js
@@ -60,7 +60,7 @@ class Bitstamp extends Exchange {
       return;
 
     if (this.api && this.api.connection.state === 'connected') {
-      this.api.disconnect();
+      this.api.close();
     }
 	}
 


### PR DESCRIPTION
There is no `disconnect` method on api, which results in `disconnect is not a function` error. Other exchanges use correct `close` method.